### PR TITLE
release: CLI-only cargo-dist + installers script

### DIFF
--- a/.github/workflows/update-packagers.yml
+++ b/.github/workflows/update-packagers.yml
@@ -34,7 +34,11 @@ jobs:
             name=$(basename "$url")
             curl -fsSL "$url" -o "dist/$name"
           done
-          for f in dist/*; do sha256sum "$f" >> dist/SHA256SUMS.txt; done
+          # Only compute SHAs for archive files (exclude .sha256, provenance, etc.)
+          for f in dist/*.tar.xz dist/*.zip; do
+            [ -f "$f" ] || continue
+            sha256sum "$f" >> dist/SHA256SUMS.txt
+          done
           cat dist/SHA256SUMS.txt
       - name: Update Homebrew tap
         env: { GH_TOKEN: ${{ secrets.GH_PAT_PUSH }} }


### PR DESCRIPTION
Public CLI repo setup: cargo-dist config, release workflow disabled (manual), installer script, and packager updater.